### PR TITLE
#4 - add reminder to add unsaved tag 

### DIFF
--- a/src/app/components/ui/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/components/ui/confirmation-modal/confirmation-modal.component.html
@@ -18,7 +18,7 @@
     <p class="text-muted-foreground mb-6">{{ message() }}</p>
     <div class="flex justify-end gap-3">
       <app-button variant="outline" (buttonClick)="onCancel()">
-        Cancel
+        {{ cancelButtonText() }}
       </app-button>
       <app-button
         [variant]="confirmButtonVariant()"

--- a/src/app/components/ui/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/components/ui/confirmation-modal/confirmation-modal.component.ts
@@ -12,6 +12,7 @@ export class ConfirmationModalComponent {
   readonly title = input.required<string>();
   readonly message = input.required<string>();
   readonly confirmButtonText = input<string>('Confirm');
+  readonly cancelButtonText = input<string>('Cancel');
   readonly confirmButtonVariant = input<'default' | 'destructive'>('default');
 
   readonly confirm = output<void>();

--- a/src/app/components/ui/confirmation-modal/confirmation-modal.service.ts
+++ b/src/app/components/ui/confirmation-modal/confirmation-modal.service.ts
@@ -12,6 +12,7 @@ export interface ConfirmationModalOptions {
   title: string;
   message: string;
   confirmButtonText?: string;
+  cancelButtonText?: string;
   confirmButtonVariant?: 'default' | 'destructive';
 }
 
@@ -34,6 +35,10 @@ export class ConfirmationModalService {
       componentRef.setInput(
         'confirmButtonText',
         options.confirmButtonText ?? 'Confirm'
+      );
+      componentRef.setInput(
+        'cancelButtonText',
+        options.cancelButtonText ?? 'Cancel'
       );
       componentRef.setInput(
         'confirmButtonVariant',

--- a/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.html
+++ b/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.html
@@ -27,6 +27,7 @@
     <app-add-tags
       [availableTags]="availableTags()"
       [(noteTags)]="noteTags"
+      [(currentTag)]="currentTag"
     ></app-add-tags>
     }
     <!-- Preview Area -->

--- a/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.ts
+++ b/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.ts
@@ -18,6 +18,7 @@ import { DeviceDetectorService } from 'ngx-device-detector';
 import { TranscriptionLanguageSelectorComponent } from '../components/transcription-language-selector/transcription-language-selector.component';
 import { TranscriptionLanguageSelectorService } from '../components/transcription-language-selector/transcription-language-selector.service';
 import { AddTagsComponent } from '../components/add-tags/add-tags.component';
+import { ConfirmationModalService } from '../../../../../components/ui/confirmation-modal/confirmation-modal.service';
 
 @Component({
   selector: 'app-create-audio-note',
@@ -43,6 +44,7 @@ export class CreateAudioNoteComponent {
   #transcriptionLanguageSelectorService = inject(
     TranscriptionLanguageSelectorService
   );
+  #confirmationModalService = inject(ConfirmationModalService);
 
   readonly recordingState = this.#recordAudioService.recordingState;
   readonly audioBlob = this.#recordAudioService.audioBlob;
@@ -54,6 +56,7 @@ export class CreateAudioNoteComponent {
   readonly noteName = signal('');
   readonly noteTags = signal<Record<string, Tag>>({});
   readonly availableTags = input<Record<string, Tag>>({});
+  readonly currentTag = signal<string>('');
   readonly currentView = signal<'recording' | 'preview'>('recording');
   readonly selectedLanguage = signal<string | null>(
     this.#transcriptionLanguageSelectorService.getSelectedLanguage()
@@ -85,13 +88,15 @@ export class CreateAudioNoteComponent {
     }
   }
 
-  handleSave(): void {
+  async handleSave(): Promise<void> {
     const customNoteName = this.noteName()?.trim();
     const blob = this.audioBlob();
     if (!blob) {
       this.#toaster.error('Please record audio first');
       return;
     }
+
+    await this.handleUnsavedTag();
     const title = customNoteName || `Note - ${new Date().toLocaleDateString()}`;
     this.noteCreated.emit({
       type: 'audio',
@@ -110,5 +115,26 @@ export class CreateAudioNoteComponent {
     this.noteName.set('');
     this.noteTags.set({});
     this.currentView.set('recording');
+  }
+
+  async handleUnsavedTag(): Promise<void> {
+    if (this.currentTag() && !this.noteTags()[this.currentTag()]) {
+      const shouldAddUnsavedTag = await this.#confirmationModalService.open({
+        title: 'Add Unsaved Tag?',
+        message: `Would you like to add "${this.currentTag()}" as a tag to this note?`,
+        confirmButtonText: 'Add',
+      });
+      if (shouldAddUnsavedTag) {
+        this.noteTags.set({
+          ...this.noteTags(),
+          [this.currentTag()]: {
+            name: this.currentTag(),
+            id: this.currentTag(),
+            updatedAt: new Date().toISOString(),
+          },
+        });
+        this.currentTag.set('');
+      }
+    }
   }
 }

--- a/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.ts
+++ b/src/app/domain/notes/components/create-note/create-audio-note/create-audio-note.component.ts
@@ -123,6 +123,7 @@ export class CreateAudioNoteComponent {
         title: 'Add Unsaved Tag?',
         message: `Would you like to add "${this.currentTag()}" as a tag to this note?`,
         confirmButtonText: 'Add',
+        cancelButtonText: 'Skip',
       });
       if (shouldAddUnsavedTag) {
         this.noteTags.set({
@@ -133,8 +134,8 @@ export class CreateAudioNoteComponent {
             updatedAt: new Date().toISOString(),
           },
         });
-        this.currentTag.set('');
       }
+      this.currentTag.set('');
     }
   }
 }


### PR DESCRIPTION
In this PR, we add a confirmation modal that appears when a user records a note without adding the tag they’ve entered in the tag input field, prompting them to confirm whether they’d like to include that tag.

<img width="787" alt="Screenshot 2025-06-16 at 23 07 46" src="https://github.com/user-attachments/assets/704793cf-5791-4c36-834e-064fd1d9db67" />

